### PR TITLE
Fix missing logger reference in main runtime

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import asyncio
 import argparse
+import logging
 import os
 import sys
 import time
@@ -17,6 +18,9 @@ from .tts_edge import EdgeTTS
 from .tts_piper import PiperTTS
 from .voice_changer_client import VoiceChangerClient, VoiceChangerConfig
 from .utils import parse_sd_device
+
+
+logger = logging.getLogger("vc-translator.main")
 
 
 def _deep_merge(a: Dict[str, Any], b: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- import the logging module in src/main.py and create a module-level logger so debug statements work without crashing

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68c9eec9975483339b0b7145b1f4db21