### PR TITLE
Add Kokoro device routing UI and enforce English TTS output

### DIFF
--- a/for_vene.bat
+++ b/for_vene.bat
@@ -1,0 +1,48 @@
+@echo off
+setlocal
+
+where python >NUL 2>&1
+if errorlevel 1 (
+    echo [ERROR] Python 3.10+ was not found on PATH.
+    echo Install Python and re-run this script.
+    exit /b 1
+)
+
+if not exist .venv (
+    echo [INFO] Creating virtual environment at .venv ...
+    python -m venv .venv
+    if errorlevel 1 (
+        echo [ERROR] Failed to create the virtual environment.
+        exit /b 1
+    )
+) else (
+    echo [INFO] Reusing existing virtual environment.
+)
+
+call .\.venv\Scripts\activate
+if errorlevel 1 (
+    echo [ERROR] Failed to activate the virtual environment.
+    exit /b 1
+)
+
+echo [INFO] Upgrading pip, setuptools, and wheel ...
+python -m pip install --upgrade pip setuptools wheel
+if errorlevel 1 (
+    echo [ERROR] Failed to upgrade pip/setuptools/wheel.
+    exit /b 1
+)
+
+echo [INFO] Installing project requirements (see requirements.txt) ...
+python -m pip install --upgrade -r requirements.txt
+if errorlevel 1 (
+    echo [ERROR] Dependency installation failed.
+    exit /b 1
+)
+
+echo.
+echo [SUCCESS] Virtual environment is ready.
+echo [SUCCESS] Activate later with: call .\.venv\Scripts\activate
+echo [SUCCESS] Launch the app with: run.bat
+
+deactivate
+endlocal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+--extra-index-url https://download.pytorch.org/whl/cpu
+# Default CPU wheels for PyTorch; adjust or remove the extra index for GPU-specific builds.
 faster-whisper>=1.0.0
 webrtcvad-wheels>=2.0.10.post2
 sounddevice>=0.4.6
@@ -12,3 +14,6 @@ sentencepiece>=0.2.0
 sacremoses>=0.1.1
 requests>=2.31.0
 pyloudnorm>=0.1.1
+torch>=2.3.0
+torchvision>=0.18.0
+torchaudio>=2.3.0

--- a/src/utils.py
+++ b/src/utils.py
@@ -9,6 +9,7 @@ import numpy as np
 from pydub import AudioSegment
 
 _HANGUL_RE = re.compile(r"[\u3130-\u318F\uAC00-\uD7A3]")
+_CJK_RE = re.compile(r"[\u3040-\u30FF\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]")
 _FILLER_RE = re.compile(
     r"(?<![\u3130-\u318F\uAC00-\uD7A3])"  # no Hangul immediately before
     r"((?:[\u3130-\u318F]*음+)|어+|그니까)(?:\s*요)?"  # filler body with optional 요
@@ -112,6 +113,16 @@ def contains_hangul(text: str) -> bool:
     if not text:
         return False
     return bool(_HANGUL_RE.search(str(text)))
+
+
+def contains_cjk(text: str) -> bool:
+    """Return True if the text contains Hangul, Kana, or Han characters."""
+
+    if not text:
+        return False
+    if contains_hangul(text):
+        return True
+    return bool(_CJK_RE.search(str(text)))
 
 
 def remove_korean_fillers(text: str) -> str:


### PR DESCRIPTION
## Summary
- add a dedicated Kokoro output row to the GUI, shared state, and device persistence so the passthrough target can be selected without editing config files
- introduce multi-language translation helpers and pipeline logic that normalize ko/ja/zh sentences to English before playback, falling back gracefully when translation fails
- update documentation to reflect the new UI routing row and the enforced English output behaviour

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ca28d607bc8333ac22591538d2b1c8