### PR TITLE
Allow auto Kokoro runtime to fall back to ONNX CPU

### DIFF
--- a/src/tts_kokoro.py
+++ b/src/tts_kokoro.py
@@ -747,7 +747,7 @@ class KokoroTTS:
                     label="PyTorch CPU",
                 )
             )
-        elif ort_mod is not None and has_cpu_provider:
+        if ort_mod is not None and has_cpu_provider:
             plans.append(
                 BackendPlan(
                     backend="onnx",


### PR DESCRIPTION
## Summary
- update Kokoro auto-backend planning so the ONNX CPU backend is still considered when PyTorch is installed
- ensure environments without the PyTorch Kokoro package can fall back to the ONNX implementation instead of failing early

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ca392343088333970c9a105120ee93