### PR TITLE
Add multilingual documentation and refresh README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,94 +1,50 @@
-Realtime Speech Translator (Windows)
+# Realtime Speech Translator (Windows)
 
-- Real-time mic capture ??VAD chunking ??Whisper translate (ko/ja/zh ??en) ??Kokoro 82M TTS playback.
-- Deterministic 16 kHz preprocessing (loudness normalization, 90 Hz high-pass, 7.2 kHz low-pass) and filler removal for Korean (????그니?.
-- Single-page desktop UI showing mic/output/Kokoro routing, fixed language pairs (ko/ja/zh ??EN), a latency gauge, and preset selector.
-- Optimized for Windows + VB-CABLE to feed TTS into a Discord voice channel.
+## Overview
+- Captures mono 16-bit PCM audio from the selected input device, segments speech with WebRTC VAD (plus optional forced segmentation), normalizes the audio, runs Faster-Whisper with filler removal and fallback translation, then synthesizes Kokoro 82M speech with optional voice conversion and multi-device playback.【F:src/audio_io.py†L10-L76】【F:src/vad.py†L19-L177】【F:src/preprocess.py†L192-L340】【F:src/asr.py†L29-L117】【F:src/pipeline.py†L331-L595】【F:src/tts_kokoro.py†L120-L366】
+- Runtime state (language, preset, devices, latency) is coordinated by a background pipeline thread so the Tk UI can update labels, latency gauges, and device choices without blocking audio processing.【F:src/pipeline.py†L144-L695】【F:src/ui.py†L10-L195】
 
-Quickstart
+## Documentation
+- [English technical overview](docs/overview.en.md)
+- [한국어 문서](docs/overview.ko.md)
+- [日本語ドキュメント](docs/overview.ja.md)
 
-- Python 3.10?3.12 recommended (examples assume 3.10)
-- Windows 10/11 64-bit
-- Optional GPU: install CUDA and use faster-whisper with float16
+## Setup
+### Requirements
+- Windows 10/11 with Python 3.10+ available on `PATH`; the bootstrap script refuses to run if Python is missing or too old.【F:for_vene.bat†L4-L26】
+- Install the dependencies listed in `requirements.txt` (Faster-Whisper, WebRTC VAD wheels, sounddevice, Kokoro runtimes, Edge/Piper TTS, PyTorch, etc.).【F:requirements.txt†L1-L21】
 
-Setup
+### Windows bootstrap script
+Run `for_vene.bat` to create/update `.venv`, upgrade pip/setuptools/wheel, and install all requirements. Successful completion prints the commands needed to activate the environment later.【F:for_vene.bat†L11-L47】
 
-1) Bootstrap the virtual environment (runs safely multiple times):
-   - Double-click `for_vene.bat` or run it from `cmd`. The script creates/updates `.venv`, upgrades `pip/setuptools/wheel`, and installs everything from `requirements.txt` (CPU PyTorch by default).
-   - GPU users can edit the `--extra-index-url` line in `requirements.txt` before running the script to target a CUDA/ROCm build from the official PyTorch index.
-   - Kokoro PyTorch/ONNX runtimes are now included in `requirements.txt`, so the default TTS backend is ready after this step. Adjust or pin the package versions there if you need specific builds.
-2) Audio routing (VB-CABLE):
-   - Set default playback to `CABLE Input` (or route with Voicemeeter)
-   - In Discord, set Input device to `CABLE Output`
-   - Disable echo cancellation / noise suppression / AGC in Discord
-3) Optional: install ffmpeg if you plan to use pydub-based features (voice changer previews, etc.):
-   - Download ffmpeg and add its `bin` to PATH
+### Manual installation outline
+1. Create and activate a virtual environment (`python -m venv .venv` → `call .\.venv\Scripts\activate`).
+2. `pip install --upgrade pip setuptools wheel`.
+3. `pip install -r requirements.txt` (remove or edit the extra index if you want a CUDA/ROCm PyTorch build).【F:for_vene.bat†L22-L45】【F:requirements.txt†L1-L21】
 
-Kokoro backend
---------------
+### Optional tools
+- Add ffmpeg to `PATH` so the preprocessor can use ffmpeg-based resampling and pydub can decode MP3 responses.【F:src/preprocess.py†L239-L295】
+- Virtual audio cables (e.g., VB-CABLE) can be selected through the device picker dialogs to mirror Kokoro output to conferencing software.【F:src/main.py†L37-L188】【F:src/tts_kokoro.py†L428-L553】
 
-- The environment bootstrap installs the official Kokoro runtime packages (PyTorch and ONNX variants) from PyPI. If you prefer a custom build, edit `requirements.txt` before running the setup script or install your desired wheels afterwards.
+## Running
+1. Activate the virtual environment and start the UI with `python -m src.main`, or run `run.bat` to activate and launch in one step.【F:run.bat†L1-L5】【F:src/main.py†L571-L588】
+2. On first launch, choose microphone/output devices (and optionally a Kokoro passthrough device); selections persist in `config/local.toml`. The UI also exposes compute mode, preset toggles, and a live latency gauge.【F:src/main.py†L404-L555】【F:src/pipeline.py†L144-L318】【F:src/ui.py†L10-L195】
+3. CLI helpers:
+   - `python -m src.main --list-devices` prints available input/output devices.
+   - `python -m src.main --list-voices` fetches Edge TTS voice metadata when the optional package is installed.【F:src/main.py†L341-L367】【F:src/main.py†L558-L588】
 
-Config
+## Configuration
+All defaults live in `config/settings.toml` and can be overridden in `config/local.toml`.
+- `[device]`: Default sample rates and device identifiers saved from the UI.【F:config/settings.toml†L1-L5】【F:src/main.py†L217-L305】
+- `[asr]`: Whisper model/device/compute type, language lock, and decoding hyperparameters.【F:config/settings.toml†L7-L15】【F:src/asr.py†L29-L147】
+- `[vad]` / `[vad.force]`: VAD aggressiveness, silence padding, chunk streaming, and forced segmentation thresholds.【F:config/settings.toml†L17-L30】【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+- `[tts]` / `[kokoro]`: Kokoro backend selection, speaker, batching/crossfade timing, output volume, passthrough input device, and warmup count.【F:config/settings.toml†L33-L58】【F:src/tts_kokoro.py†L120-L553】
+- `[app]`: Default preset (`latency` or `accuracy`) and compute mode preference; the runtime verifies CUDA availability and falls back to CPU when needed.【F:config/settings.toml†L60-L61】【F:src/main.py†L369-L530】
+- `[voice_changer]`: Disabled (`enabled = false`) by default—VCC export is inactive until you opt in. Configure base URL, endpoints, sample rates, streaming chunk size, and fallback playback device here.【F:config/settings.toml†L67-L79】【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
 
-Edit `config/settings.toml` to adjust devices, model size, presets, and Kokoro tuning.
-Defaults:
-- Capture at the device sample rate, preprocess to 16 kHz mono with loudnorm (I=-16, TP=-1.5, LRA=11) and 90??200 Hz band-pass before Whisper.
-- Whisper `large-v3-turbo` on CPU (`int8` compute) so the ASR step stays responsive without a GPU.
-- VAD 30 ms frames, aggressiveness 2, silence tail 300 ms (streaming chunking comes from the preset values).
-- Kokoro 82M TTS with 120 ms crossfade and sentence queueing.
-- `[app].preset = "latency"` (1000??200 ms chunk, 250 ms hop, beam 3). Switch to `"accuracy"` for longer chunks and higher beam width.
+## Voice Conversion / VCC
+When `voice_changer.enabled` remains `false`, Kokoro audio is only played locally. Enabling it sends Kokoro output to the Ookada VC Client API, with optional WAV logging of original and converted audio. This increases latency slightly and requires the HTTP endpoint to be available.【F:config/settings.toml†L67-L79】【F:src/tts_kokoro.py†L320-L366】【F:src/voice_changer_client.py†L113-L184】
 
-Run
-
-- Activate venv: `.\.venv\Scripts\activate`
-- Start: `python -m src.main` (a single-window UI appears showing selected devices, fixed language toggle, preset buttons, and a live latency gauge)
-- Or use helper: `run.bat`
-
-CLI Helpers
-
-- List audio devices: `python -m src.main --list-devices`
-- List Edge TTS voices: `python -m src.main --list-voices`
-- Override common settings at launch:
-  - `--input-device "Your Mic"` or index
-  - `--output-device "CABLE Input"` or index
-  - `--language ko|ja|zh`
-  - `--preset latency|accuracy`
-  - Use `--config` to point at a different TOML file
-
-Kokoro 82M GPU TTS
-------------------
-
-- Kokoro 82M is the only TTS path (no Edge/Piper fallback). `[tts].engine` remains `"kokoro"` for completeness.
-- Backend auto-probing is enabled by default (`[kokoro].backend = "auto"`, `[kokoro].device = "auto"`). At startup the app benchmarks CUDA ??ROCm ??DirectML ??CPU with a one-second dummy sentence on the available runtimes (PyTorch or ONNX) and locks in the fastest option. If the active backend spikes above the running average by more than `2?` for three consecutive sentences it automatically falls back to the next fastest candidate.
-- Pick a Kokoro voice and set `[kokoro].speaker` (defaults to "af_bella"). Voice files follow the repository naming (`af_*`, `am_*`, `bf_*`, etc.) in `hexgrad/Kokoro-82M/voices`.
-- Device priority matches the hardware:
-  - NVIDIA GPUs stick to PyTorch + CUDA (`use_half = true` keeps FP16 inference).
-  - AMD on Linux prefers ONNX + ROCm; Windows systems without NVIDIA prefer ONNX + DirectML.
-  - CPU-only mode is kept as a final fallback when no GPU runtime is available.
-- Mirror Kokoro playback to a virtual microphone by setting `[kokoro].passthrough_input_device` to the input device index/name (e.g. the 3rd input device). Audio continues to play on the main output while also feeding the specified input.
-- To pin a specific configuration, override `[kokoro].backend`, `[kokoro].device`, or `[kokoro].onnx_providers` and rerun. CLI overrides such as `--kokoro-backend onnx` or `--kokoro-provider DmlExecutionProvider` are still supported.
-- Built-in queueing keeps playback smooth: sentences are batched until the group reaches roughly 0.8??.2?s, a fixed 120?ms crossfade blends consecutive utterances, and short clips flush automatically when speech pauses. The tunables (`short_threshold_ms`, `min_batch_ms`, `max_batch_ms`, `crossfade_ms`, etc.) live under `[kokoro]` if you need to tweak them.
-- Kokoro playback is skipped automatically if translation fails and non-English (Hangul/Kana/Han) characters remain after the fallback translator pass.
-- `[kokoro].passthrough_input_device` can now be set directly from the UI ("Kokoro 출력" row) instead of editing the config file.
-
-Voice Changer Integration
-
-- Default run saves the raw Kokoro waveform to `cache/tts_original.wav`.
-- Set `[voice_changer].enabled = true` in `config/settings.toml` to pipe each utterance into Ookada's VCClient at `http://localhost:18000` via the `/api/voice-changer/convert_chunk` endpoint.
-- When enabled, the converted audio replaces the playback stream and is also written to `cache/tts_converted.wav`. The client auto-detects sample rates from `/api/configuration-manager/configuration`; override `input_sample_rate`/`output_sample_rate` if you need fixed values.
-- Tune `timeout_sec`, `base_url`, or `endpoint` to match your VCClient deployment. If the HTTP call fails, the app logs the reason, optionally retries `/api/voice-changer/convert_chunk_bulk`, and falls back to the original TTS audio.
-- Optional streaming: set `[voice_changer].stream_mode = true` to send smaller chunks (default 1000 ms, configure with `stream_chunk_ms`) so converted audio starts while later chunks process.
-
-Notes
-
-- Translation to English is enforced for the supported input languages (ko/ja/zh). Whisper handles the primary translation and, if residual CJK text remains, the app falls back to the Helsinki-NLP ko/ja/zh ??en models before speaking.
-- If audio plays too loud/quiet, tune `[tts].volume_db` and `[stream].normalize_dbfs`.
-- Whisper �?�� 길이�??�리�??�다�?[vad].listen_max_sec, [vad].listen_silence_ms, chunk_min_ms, chunk_max_ms�?조정???�그먼트 분할 ?�점????�� ???�습?�다.
-- Set `[logging].level = "DEBUG"` to enable per-segment ASR/TTS timing logs while tuning performance.
-- For CPU-only, set `[asr].device = "cpu"` and `compute_type = "int8"` or `"int8_float16"`.
-- For Piper TTS, set `[tts].engine = "piper"` and provide `[tts].piper_model` path to a `.onnx` or `.tar` bundle, then install Piper models separately.
-- Korean fillers (`??, `??, `그니?) are stripped before translation so Whisper/Kokoro only see meaningful speech.
-
-
-
+## Tips
+- Switch compute acceleration at launch with `--compute-mode auto|cpu|cuda`; requests for CUDA gracefully fall back to CPU if CUDA is unavailable.【F:src/main.py†L369-L530】
+- Extend `LANGUAGE_OPTIONS` and `LANGUAGE_MODELS` to support additional source languages—the shared state and UI already handle dynamic language switching.【F:src/pipeline.py†L39-L655】【F:src/translator.py†L10-L73】【F:src/ui.py†L84-L153】

--- a/docs/overview.en.md
+++ b/docs/overview.en.md
@@ -1,0 +1,51 @@
+# Realtime Speech Translator – Technical Overview (English)
+
+## Overview
+The application records mono 16-bit PCM audio from a selectable input device, detects speech boundaries, performs Whisper-based automatic speech recognition (ASR) with Korean filler removal and optional Helsinki-NLP translation, then plays back Kokoro 82M speech synthesis with optional voice conversion. All runtime state is coordinated through a background pipeline that keeps the UI responsive and tracks end-to-end latency.【F:src/audio_io.py†L10-L76】【F:src/vad.py†L19-L177】【F:src/asr.py†L29-L147】【F:src/pipeline.py†L331-L595】
+
+## Signal Flow
+1. **Capture:** `MicReader` uses a `sounddevice.RawInputStream` to queue fixed-size frames from the configured input device, allowing the pipeline thread to read audio without blocking the callback.【F:src/audio_io.py†L10-L76】
+2. **Segmentation:** `VADSegmenter` applies WebRTC VAD with configurable frame, aggressiveness, max utterance duration, and optional chunk streaming. When enabled, `ForcedSegmenter` monitors RMS levels to force a cut if VAD misses the end of long or loud phrases.【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+3. **Preprocessing:** `AudioPreprocessor` resamples to 16 kHz (ffmpeg when available, otherwise an internal resampler), runs 90 Hz high-pass and 7.2 kHz low-pass biquads, and applies loudness normalization, true-peak limiting, and gentle compression before ASR.【F:src/preprocess.py†L192-L340】
+4. **Recognition:** The ASR wrapper converts PCM bytes to float32, resamples, invokes Faster-Whisper with configurable model/beam/temperature, strips Korean fillers, and optionally performs a second pass with Helsinki-NLP translators for ko/ja/zh → en if Whisper left CJK characters.【F:src/asr.py†L29-L117】【F:src/pipeline.py†L556-L639】【F:src/translator.py†L10-L66】
+5. **Synthesis:** `KokoroTTS` batches short sentences, crossfades overlapping utterances, and can mirror audio to the main output, a passthrough virtual mic, and a fallback device when voice conversion fails.【F:src/tts_kokoro.py†L120-L246】【F:src/tts_kokoro.py†L320-L366】【F:src/tts_kokoro.py†L428-L553】
+6. **Voice conversion (optional):** If enabled, the pipeline instantiates `VoiceChangerClient`, which uploads int16 chunks to an Ookada VC Client endpoint, resamples to negotiated rates, supports streaming mode, and writes optional WAV traces.【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+7. **State/UI:** `SharedState` synchronizes requested vs. active language, preset, devices, and latency; `TranslatorUI` lets the user change devices, presets, compute mode, and Kokoro mirroring while the pipeline applies changes live.【F:src/pipeline.py†L144-L695】【F:src/ui.py†L10-L195】
+
+## Setup
+### Dependencies
+All Python requirements—including Faster-Whisper, WebRTC VAD wheels, sounddevice, Kokoro runtimes, Edge/Piper TTS, and PyTorch—are pinned in `requirements.txt`. The default extra index installs CPU PyTorch; edit or remove it for CUDA/ROCm builds.【F:requirements.txt†L1-L21】
+
+### Windows bootstrap script
+`for_vene.bat` provisions or reuses a `.venv`, upgrades packaging tools, and installs dependencies. It shows the commands needed for manual setup if you prefer PowerShell or cmd steps individually.【F:for_vene.bat†L1-L47】
+
+### Manual setup outline
+1. Create and activate a Python 3.10–3.12 virtual environment.
+2. `pip install --upgrade pip setuptools wheel`.
+3. `pip install -r requirements.txt` (adjust the PyTorch wheel index if targeting GPU builds).【F:for_vene.bat†L22-L45】【F:requirements.txt†L1-L21】
+
+### Optional tools
+- Install ffmpeg and add it to `PATH` so Kokoro and pydub can decode MP3 assets and so the preprocessor can use ffmpeg-based resampling.【F:src/preprocess.py†L239-L295】
+- VB-CABLE or a similar virtual audio device can be selected through the device pickers for routing Kokoro output to conferencing software.【F:src/main.py†L37-L188】
+
+## Running the Application
+1. Activate the virtual environment (`.\.venv\Scripts\activate` on Windows) and start the UI with `python -m src.main` or simply run `run.bat`, which performs the activation automatically.【F:run.bat†L1-L5】【F:src/main.py†L571-L588】
+2. On first launch the GUI prompts for microphone and output devices; selections persist to `config/local.toml`. The UI also exposes compute mode toggles, Kokoro passthrough mirroring, and latency feedback.【F:src/main.py†L404-L555】【F:src/pipeline.py†L144-L318】【F:src/ui.py†L10-L195】
+3. CLI helpers: `python -m src.main --list-devices` enumerates sound devices, while `--list-voices` fetches Edge TTS voices when the optional package is available.【F:src/main.py†L341-L367】【F:src/main.py†L558-L588】
+
+## Configuration Highlights
+Edit `config/settings.toml` (and override in `config/local.toml`) to control runtime behavior:
+- `[device]`: default input/output sample rates and device identifiers saved by the UI.【F:config/settings.toml†L1-L5】【F:src/main.py†L217-L305】
+- `[asr]`: Whisper model, device/compute type, language lock, and decoding hyperparameters.【F:config/settings.toml†L7-L15】【F:src/asr.py†L29-L147】
+- `[vad]` and `[vad.force]`: VAD aggressiveness, silence padding, chunk streaming, and forced segmentation thresholds.【F:config/settings.toml†L17-L30】【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+- `[tts]` and `[kokoro]`: Kokoro backend, speaker, batching/crossfade timings, output volume, and optional passthrough input device for virtual-mic mirroring.【F:config/settings.toml†L33-L58】【F:src/tts_kokoro.py†L120-L553】
+- `[app]`: default preset (`latency` or `accuracy`) and compute mode selection that maps to CPU or CUDA at runtime.【F:config/settings.toml†L60-L61】【F:src/main.py†L369-L530】
+- `[voice_changer]`: Disabled by default—VCC export is inactive until you set `enabled = true`. When activated you can choose endpoints, sample rates, streaming chunk length, and fallback playback device.【F:config/settings.toml†L67-L79】【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+
+## Voice Conversion / VCC Notes
+Because `voice_changer.enabled` defaults to `false`, the application does not send Kokoro audio to the Ookada VC Client unless you explicitly enable it. When disabled the pipeline simply plays Kokoro audio to the configured outputs; enabling it introduces HTTP conversion requests and optional WAV exports for the raw and converted audio.【F:config/settings.toml†L67-L79】【F:src/tts_kokoro.py†L320-L366】【F:src/voice_changer_client.py†L113-L184】
+
+## Extensibility Tips
+- Adjust compute mode with `--compute-mode auto|cpu|cuda`; the pipeline verifies CUDA availability and falls back to CPU when necessary.【F:src/main.py†L369-L530】
+- Add new language targets by extending `LANGUAGE_MODELS` and the UI combobox options; the shared state and pipeline already support dynamic language switching.【F:src/translator.py†L10-L73】【F:src/pipeline.py†L144-L655】【F:src/ui.py†L84-L153】
+- Integrate alternative TTS backends by adapting `KokoroTTS` or reusing the optional `EdgeTTS` and `PiperTTS` implementations under `src/tts_edge.py` and `src/tts_piper.py`.

--- a/docs/overview.ja.md
+++ b/docs/overview.ja.md
@@ -1,0 +1,51 @@
+# リアルタイム音声翻訳 – 技術概要 (日本語)
+
+## 概要
+本アプリケーションは選択した入力デバイスからモノラル16bit PCM音声を取得し、発話区間を検出してからWhisperベースの音声認識を実行します。韓国語フィラー除去やHelsinki-NLPによるko/ja/zh→英語訳を行い、Kokoro 82Mによる音声合成を再生します。音声変換(VCC)連携は任意で、UIとは別スレッドのパイプラインが全体の状態と遅延を管理します。【F:src/audio_io.py†L10-L76】【F:src/vad.py†L19-L177】【F:src/asr.py†L29-L147】【F:src/pipeline.py†L331-L595】
+
+## 信号フロー
+1. **キャプチャ:** `MicReader` が `sounddevice.RawInputStream` を用いて固定サイズのフレームをキューに蓄積し、コールバックがブロックされないようにします。【F:src/audio_io.py†L10-L76】
+2. **区間抽出:** `VADSegmenter` はフレーム長・感度・最大発話時間・チャンクストリーミングを設定できる WebRTC VAD を利用します。`ForcedSegmenter` を有効化すると、RMS レベルを監視して長い発話を強制的に切り出します。【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+3. **前処理:** `AudioPreprocessor` は可能なら ffmpeg で16kHzへリサンプリングし、90Hz ハイパスと 7.2kHz ローパスを適用後、ラウドネス正規化・トゥルーピーク制限・緩やかなコンプレッションを行います。【F:src/preprocess.py†L192-L340】
+4. **認識:** ASR ラッパーは PCM を float32 に変換して Faster-Whisper を呼び出し、韓国語フィラーを削除した後に CJK 文字が残る場合は Helsinki-NLP 翻訳器で英語へ変換します。【F:src/asr.py†L29-L117】【F:src/pipeline.py†L556-L639】【F:src/translator.py†L10-L66】
+5. **合成:** `KokoroTTS` は短い文をバッチ化してクロスフェードしながら再生し、メイン出力・パススルー用仮想マイク・VC失敗時のフォールバックデバイスへ同時にルーティングできます。【F:src/tts_kokoro.py†L120-L246】【F:src/tts_kokoro.py†L320-L366】【F:src/tts_kokoro.py†L428-L553】
+6. **音声変換 (任意):** 有効化すると `VoiceChangerClient` が生成され、Ookada VC Client API に int16 チャンクを送信し、サンプルレートの協調やストリーミング、WAV 保存を処理します。【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+7. **状態とUI:** `SharedState` が言語・プリセット・デバイス・遅延を同期し、`TranslatorUI` がデバイス切替・プリセット・計算モード・Kokoroミラーをリアルタイムに操作できる Tk UI を提供します。【F:src/pipeline.py†L144-L695】【F:src/ui.py†L10-L195】
+
+## セットアップ
+### 依存パッケージ
+Faster-Whisper、WebRTC VAD、sounddevice、Kokoro ランタイム、Edge/Piper TTS、PyTorch などは `requirements.txt` にまとめてあります。デフォルトの extra-index は CPU 版 PyTorch を指しているので、GPU 版が必要なら編集してください。【F:requirements.txt†L1-L21】
+
+### Windows ブートストラップ
+`for_vene.bat` は `.venv` を作成または再利用し、ビルドツールを更新してから依存パッケージをインストールします。手動セットアップの参考になるコマンドもログに表示されます。【F:for_vene.bat†L1-L47】
+
+### 手動セットアップ手順
+1. Python 3.10〜3.12 の仮想環境を作成し、アクティブ化します。
+2. `pip install --upgrade pip setuptools wheel` を実行します。
+3. `pip install -r requirements.txt` を実行し、必要に応じて PyTorch のインデックス URL を変更します。【F:for_vene.bat†L22-L45】【F:requirements.txt†L1-L21】
+
+### オプションツール
+- ffmpeg を PATH に追加すると、Kokoro/pydub で MP3 を扱え、前処理の ffmpeg リサンプラーも利用できます。【F:src/preprocess.py†L239-L295】
+- VB-CABLE などの仮想オーディオデバイスは GUI のデバイス選択ダイアログから指定でき、配信ソフト等へルーティングできます。【F:src/main.py†L37-L188】
+
+## 実行方法
+1. 仮想環境をアクティブ化し、`python -m src.main` を実行するか `run.bat` を利用して自動的に起動します。【F:run.bat†L1-L5】【F:src/main.py†L571-L588】
+2. 初回起動時はマイクと出力デバイスを選択し、設定は `config/local.toml` に保存されます。UI では計算モード切替、Kokoro パススルー、遅延ゲージを確認できます。【F:src/main.py†L404-L555】【F:src/pipeline.py†L144-L318】【F:src/ui.py†L10-L195】
+3. CLI ヘルパー: `python -m src.main --list-devices` でデバイス一覧を表示し、`--list-voices` で Edge TTS ボイスを取得できます。【F:src/main.py†L341-L367】【F:src/main.py†L558-L588】
+
+## 設定の要点
+`config/settings.toml` を編集するか `config/local.toml` で上書きして挙動を調整します。
+- `[device]`: 既定のサンプルレートとデバイス ID。UI が保存／復元します。【F:config/settings.toml†L1-L5】【F:src/main.py†L217-L305】
+- `[asr]`: Whisper モデル、デバイス／演算形式、言語ロック、デコード設定。【F:config/settings.toml†L7-L15】【F:src/asr.py†L29-L147】
+- `[vad]`, `[vad.force]`: VAD 感度、サイレンスパッド、チャンクストリーミング、強制分割の閾値。【F:config/settings.toml†L17-L30】【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+- `[tts]`, `[kokoro]`: Kokoro バックエンド／スピーカー、バッチ／クロスフェード設定、出力音量、パススルーデバイス。【F:config/settings.toml†L33-L58】【F:src/tts_kokoro.py†L120-L553】
+- `[app]`: 既定プリセット (`latency` / `accuracy`) と計算モード。実行時に CUDA の有無を確認して切り替えます。【F:config/settings.toml†L60-L61】【F:src/main.py†L369-L530】
+- `[voice_changer]`: 既定で `false` のため VCC 出力は無効です。`enabled = true` にするとエンドポイントやサンプルレート、ストリームチャンク、フォールバック出力を設定できます。【F:config/settings.toml†L67-L79】【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+
+## VCC (Voice Changer Client) に関する注意
+`voice_changer.enabled` が `false` のままでは Kokoro 音声は VC クライアントへ送信されません。無効時は Kokoro 音声のみ再生され、有効化すると HTTP 変換リクエストと原音／変換後 WAV の保存が行われます。【F:config/settings.toml†L67-L79】【F:src/tts_kokoro.py†L320-L366】【F:src/voice_changer_client.py†L113-L184】
+
+## 拡張のヒント
+- `--compute-mode auto|cpu|cuda` を指定すると CUDA 利用可否を自動判定し、適切なモードに切り替えます。【F:src/main.py†L369-L530】
+- `LANGUAGE_MODELS` と UI のコンボボックスを拡張すれば新しい言語に対応できます。共有状態とパイプラインは既に動的な言語切替をサポートしています。【F:src/translator.py†L10-L73】【F:src/pipeline.py†L144-L655】【F:src/ui.py†L84-L153】
+- `src/tts_edge.py` や `src/tts_piper.py` を参考に別の TTS バックエンドを追加したり、`KokoroTTS` を拡張できます。

--- a/docs/overview.ko.md
+++ b/docs/overview.ko.md
@@ -1,0 +1,51 @@
+# 실시간 음성 번역기 – 기술 개요 (한국어)
+
+## 개요
+이 애플리케이션은 선택한 입력 장치에서 모노 16비트 PCM 오디오를 받아 말하기 구간을 검출한 뒤, 한국어 군더더기 제거가 포함된 Whisper 기반 음성 인식과 필요 시 Helsinki-NLP 번역을 수행하고, Kokoro 82M 음성 합성 결과를 재생합니다. 음성 변환(VC) 연동은 옵션이며, 모든 상태 관리는 UI와 분리된 파이프라인 스레드가 담당해 전체 지연 시간을 추적합니다.【F:src/audio_io.py†L10-L76】【F:src/vad.py†L19-L177】【F:src/asr.py†L29-L147】【F:src/pipeline.py†L331-L595】
+
+## 신호 흐름
+1. **캡처:** `MicReader`가 `sounddevice.RawInputStream`을 이용해 고정 크기 프레임을 큐에 쌓아, 콜백이 막히지 않도록 합니다.【F:src/audio_io.py†L10-L76】
+2. **분할:** `VADSegmenter`는 프레임 길이, 민감도, 최대 발화 길이, 청크 스트리밍을 설정할 수 있는 WebRTC VAD를 사용합니다. `ForcedSegmenter`를 켜면 RMS 기반으로 VAD가 놓친 긴 발화를 강제로 잘라냅니다.【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+3. **전처리:** `AudioPreprocessor`는 ffmpeg(가능하면) 또는 내부 보간기로 16kHz로 리샘플링한 뒤 90Hz 하이패스와 7.2kHz 로우패스를 거치고, 라우드니스 정규화·트루픽 제한·완만한 컴프레서를 적용합니다.【F:src/preprocess.py†L192-L340】
+4. **인식:** ASR 래퍼는 PCM을 float32로 바꾼 뒤 Faster-Whisper를 호출하고, 한국어 군더더기를 제거한 뒤 필요하면 ko/ja/zh → en Helsinki-NLP 모델로 후처리합니다.【F:src/asr.py†L29-L117】【F:src/pipeline.py†L556-L639】【F:src/translator.py†L10-L66】
+5. **합성:** `KokoroTTS`는 짧은 문장을 모아 배치 처리하고, 교차 페이드로 이어 붙이며, 메인 출력·패스스루 가상 마이크·VC 실패 시 폴백 장치로 동시에 출력할 수 있습니다.【F:src/tts_kokoro.py†L120-L246】【F:src/tts_kokoro.py†L320-L366】【F:src/tts_kokoro.py†L428-L553】
+6. **음성 변환(선택):** 활성화하면 파이프라인이 `VoiceChangerClient`를 생성하여 Ookada VC Client API에 int16 청크를 업로드하고, 샘플레이트 협상·스트리밍·WAV 저장을 처리합니다.【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+7. **상태/GUI:** `SharedState`가 언어·프리셋·장치·지연 시간을 동기화하고, `TranslatorUI`는 장치/프리셋/연산 모드/Kokoro 미러링을 실시간으로 변경할 수 있는 Tk 인터페이스를 제공합니다.【F:src/pipeline.py†L144-L695】【F:src/ui.py†L10-L195】
+
+## 설치
+### 필수 패키지
+Faster-Whisper, WebRTC VAD, sounddevice, Kokoro 런타임, Edge/Piper TTS, PyTorch 등 모든 의존성은 `requirements.txt`에 정의되어 있습니다. 기본 extra-index는 CPU용 PyTorch를 설치하므로, GPU 빌드가 필요하면 수정하거나 제거하세요.【F:requirements.txt†L1-L21】
+
+### Windows 자동 구성 스크립트
+`for_vene.bat`은 `.venv`를 생성/재사용하고 패키징 도구를 업그레이드한 뒤 요구 패키지를 설치합니다. PowerShell/cmd로 수동 실행하고 싶을 때 참고용 명령도 모두 표시됩니다.【F:for_vene.bat†L1-L47】
+
+### 수동 설치 절차
+1. Python 3.10–3.12 가상환경을 만들고 활성화합니다.
+2. `pip install --upgrade pip setuptools wheel` 실행.
+3. `pip install -r requirements.txt` (GPU용 PyTorch를 원하면 인덱스 URL을 조정).【F:for_vene.bat†L22-L45】【F:requirements.txt†L1-L21】
+
+### 선택 도구
+- ffmpeg를 PATH에 추가하면 Kokoro/pydub MP3 디코드와 전처리의 ffmpeg 리샘플링을 사용할 수 있습니다.【F:src/preprocess.py†L239-L295】
+- VB-CABLE과 같은 가상 오디오 장치는 GUI 장치 선택기에서 지정해 Discord 등으로 라우팅할 수 있습니다.【F:src/main.py†L37-L188】
+
+## 실행 방법
+1. 가상환경을 활성화한 뒤 `python -m src.main` 또는 자동 활성화를 포함한 `run.bat`을 실행합니다.【F:run.bat†L1-L5】【F:src/main.py†L571-L588】
+2. 최초 실행 시 마이크와 출력 장치를 선택하며, 이후 값은 `config/local.toml`에 저장됩니다. UI에서는 연산 모드 전환, Kokoro 패스스루 장치, 지연 게이지를 실시간으로 확인할 수 있습니다.【F:src/main.py†L404-L555】【F:src/pipeline.py†L144-L318】【F:src/ui.py†L10-L195】
+3. CLI 도구: `python -m src.main --list-devices`로 오디오 장치를 확인하고, `--list-voices`로 Edge TTS 보이스 목록을 조회할 수 있습니다.【F:src/main.py†L341-L367】【F:src/main.py†L558-L588】
+
+## 설정 요약
+`config/settings.toml`을 수정하거나 `config/local.toml`로 덮어써 세부 동작을 조정합니다.
+- `[device]`: 기본 샘플레이트와 장치 ID. UI가 저장/불러오기 합니다.【F:config/settings.toml†L1-L5】【F:src/main.py†L217-L305】
+- `[asr]`: Whisper 모델, 디바이스/정밀도, 언어 고정, 디코딩 옵션.【F:config/settings.toml†L7-L15】【F:src/asr.py†L29-L147】
+- `[vad]`, `[vad.force]`: VAD 민감도, 침묵 패드, 청크 스트리밍, 강제 분할 임계값.【F:config/settings.toml†L17-L30】【F:src/vad.py†L19-L177】【F:src/pipeline.py†L405-L545】
+- `[tts]`, `[kokoro]`: Kokoro 백엔드/보이스, 배치·크로스페이드 타이밍, 출력 볼륨, 패스스루 장치 설정.【F:config/settings.toml†L33-L58】【F:src/tts_kokoro.py†L120-L553】
+- `[app]`: 기본 프리셋(`latency`/`accuracy`)과 연산 모드 지정. 런타임에서 CUDA 가용성에 맞춰 조정됩니다.【F:config/settings.toml†L60-L61】【F:src/main.py†L369-L530】
+- `[voice_changer]`: 기본값이 `false`라서 VCC 내보내기가 꺼져 있습니다. `enabled = true`로 바꾸면 엔드포인트, 샘플레이트, 스트리밍 청크 길이, 폴백 출력 장치를 설정할 수 있습니다.【F:config/settings.toml†L67-L79】【F:src/pipeline.py†L706-L739】【F:src/voice_changer_client.py†L21-L184】
+
+## VCC(Voice Changer Client) 안내
+`voice_changer.enabled`가 `false`이므로 기본 상태에서는 Kokoro 오디오가 VC 클라이언트로 전송되지 않습니다. 비활성화 시 Kokoro 음성만 바로 재생하며, 활성화하면 HTTP 변환 요청과 원본/변환 WAV 저장이 추가됩니다.【F:config/settings.toml†L67-L79】【F:src/tts_kokoro.py†L320-L366】【F:src/voice_changer_client.py†L113-L184】
+
+## 확장 팁
+- `--compute-mode auto|cpu|cuda` 인자를 사용하면 CUDA 지원 여부를 자동 확인해 적절한 모드로 전환합니다.【F:src/main.py†L369-L530】
+- 새로운 언어를 추가하려면 `LANGUAGE_MODELS`와 UI 콤보박스를 확장하세요. 공유 상태와 파이프라인은 이미 동적 언어 전환을 지원합니다.【F:src/translator.py†L10-L73】【F:src/pipeline.py†L144-L655】【F:src/ui.py†L84-L153】
+- `src/tts_edge.py`, `src/tts_piper.py`의 예시처럼 다른 TTS 백엔드를 연결하거나 `KokoroTTS`를 확장할 수 있습니다.


### PR DESCRIPTION
## Summary
- add detailed English, Korean, and Japanese technical guides under docs/
- rewrite the README with setup, runtime usage, configuration, and VCC notes that link to the new docs

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68ccd16543448333a0197cc98504007c