### PR TITLE
Enable LLM translation pipeline

### DIFF
--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -498,6 +498,7 @@ class TranslatorPipeline:
             input_sr=preproc.target_sr,
             temperature=preset.temperature,
         )
+        asr.set_force_transcribe(self.state.get_llm_translate_active())
         self.state.set_active_language(asr_cfg.get("language", "ko"))
         self.state.set_active_preset(preset.key)
 
@@ -782,6 +783,7 @@ class TranslatorPipeline:
             self._translator_settings["use_llm"] = enabled
             self.state.set_active_llm_translate(enabled)
             self._persist_devices()
+        asr.set_force_transcribe(self.state.get_llm_translate_active())
 
     def _switch_input_device(self, device: Optional[object]) -> None:
         parsed = parse_sd_device(device)


### PR DESCRIPTION
## Summary
- force Whisper into transcribe mode whenever the UI enables LLM translation so the external model receives the original CJK text
- add an ASR toggle that bypasses the built-in Helsinki translator when LLM translation is active and re-evaluates when disabled
- harden the LLM REST client to fall back cleanly when models are missing or requests fail

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68ccda7a71a883338d2063def9cc054a