### PR TITLE
Force Whisper to use CUDA acceleration

### DIFF
--- a/config/settings.toml
+++ b/config/settings.toml
@@ -7,7 +7,7 @@ output_device = ""
 [asr]
 whisper_model = "medium" # recommended: large-v3-turbo for accuracy, medium for lower load
 device = "cuda"
-compute_type = "int8"
+compute_type = "float16"  # CUDA acceleration; cpu mode will override to int8
 task = "translate"
 language = "ko"
 beam_size = 2


### PR DESCRIPTION
## Summary
- default Whisper ASR configuration now normalizes empty device values to CUDA and upgrades CUDA + int8 combinations to GPU-friendly settings
- update the default configuration to request float16 compute for CUDA acceleration with documentation in settings

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68cdd8d311c88333851e3266ea1641ea